### PR TITLE
Jking/add scrub

### DIFF
--- a/src/java/org/apache/cassandra/tools/StandaloneScrubber.java
+++ b/src/java/org/apache/cassandra/tools/StandaloneScrubber.java
@@ -54,6 +54,7 @@ public class StandaloneScrubber
     private static final String MANIFEST_CHECK_OPTION  = "manifest-check";
     private static final String SKIP_CORRUPTED_OPTION = "skip-corrupted";
     private static final String NO_VALIDATE_OPTION = "no-validate";
+    private static final String DROP_TOMBSTONES_OPTION = "drop-tombstones";
 
     public static void main(String args[])
     {
@@ -110,7 +111,7 @@ public class StandaloneScrubber
                 {
                     try
                     {
-                        Scrubber scrubber = new Scrubber(cfs, sstable, options.skipCorrupted, handler, true, !options.noValidate);
+                        Scrubber scrubber = new Scrubber(cfs, sstable, options.skipCorrupted, handler, true, !options.noValidate, options.dropTombstones);
                         try
                         {
                             scrubber.scrub();
@@ -189,6 +190,7 @@ public class StandaloneScrubber
         public boolean manifestCheckOnly;
         public boolean skipCorrupted;
         public boolean noValidate;
+        public boolean dropTombstones;
 
         private Options(String keyspaceName, String cfName)
         {
@@ -229,6 +231,7 @@ public class StandaloneScrubber
                 opts.manifestCheckOnly = cmd.hasOption(MANIFEST_CHECK_OPTION);
                 opts.skipCorrupted = cmd.hasOption(SKIP_CORRUPTED_OPTION);
                 opts.noValidate = cmd.hasOption(NO_VALIDATE_OPTION);
+                opts.dropTombstones = cmd.hasOption(DROP_TOMBSTONES_OPTION);
 
                 return opts;
             }
@@ -255,6 +258,7 @@ public class StandaloneScrubber
             options.addOption("m",  MANIFEST_CHECK_OPTION, "only check and repair the leveled manifest, without actually scrubbing the sstables");
             options.addOption("s",  SKIP_CORRUPTED_OPTION, "skip corrupt rows in counter tables");
             options.addOption("n",  NO_VALIDATE_OPTION,    "do not validate columns using column validator");
+            options.addOption("d", DROP_TOMBSTONES_OPTION, "drop tombstons when compacting");
             return options;
         }
 


### PR DESCRIPTION
Add the ability to drop tombstones when scrubbing from the command line. Also adding the ability to scrub individual sstables instead of the entire cf. I'll probably send another PR with some cleanup. To run the scrub on a file run:

Example use:
sstablescrub -d -f /var/lib/cassandra/timeslice_store/minute_timeslice_blobs-16395660ba4e11e58bdec12de94ec9ee/timeslice_store-minute_timeslice_blobs-ka-13958-Data.db

@wulczer @intjonathan @jfernandez 
