### PR TITLE
Add a new column family option: hint_time_to_live_seconds

### DIFF
--- a/interface/cassandra.thrift
+++ b/interface/cassandra.thrift
@@ -55,7 +55,7 @@ namespace rb CassandraThrift
 # An effort should be made not to break forward-client-compatibility either
 # (e.g. one should avoid removing obsolete fields from the IDL), but no
 # guarantees in this respect are made by the Cassandra project.
-const string VERSION = "20.1.0"
+const string VERSION = "20.2.0"
 
 
 #
@@ -474,6 +474,7 @@ struct CfDef {
     44: optional string cells_per_row_to_cache = "100",
     45: optional i32 min_index_interval,
     46: optional i32 max_index_interval,
+    47: optional i32 hint_time_to_live_seconds,
 
     /* All of the following are now ignored and unsupplied. */
 

--- a/interface/thrift/gen-java/org/apache/cassandra/thrift/CfDef.java
+++ b/interface/thrift/gen-java/org/apache/cassandra/thrift/CfDef.java
@@ -85,6 +85,7 @@ public class CfDef implements org.apache.thrift.TBase<CfDef, CfDef._Fields>, jav
   private static final org.apache.thrift.protocol.TField CELLS_PER_ROW_TO_CACHE_FIELD_DESC = new org.apache.thrift.protocol.TField("cells_per_row_to_cache", org.apache.thrift.protocol.TType.STRING, (short)44);
   private static final org.apache.thrift.protocol.TField MIN_INDEX_INTERVAL_FIELD_DESC = new org.apache.thrift.protocol.TField("min_index_interval", org.apache.thrift.protocol.TType.I32, (short)45);
   private static final org.apache.thrift.protocol.TField MAX_INDEX_INTERVAL_FIELD_DESC = new org.apache.thrift.protocol.TField("max_index_interval", org.apache.thrift.protocol.TType.I32, (short)46);
+  private static final org.apache.thrift.protocol.TField HINT_TIME_TO_LIVE_SECONDS_FIELD_DESC = new org.apache.thrift.protocol.TField("hint_time_to_live_seconds", org.apache.thrift.protocol.TType.I32, (short)47);
   private static final org.apache.thrift.protocol.TField ROW_CACHE_SIZE_FIELD_DESC = new org.apache.thrift.protocol.TField("row_cache_size", org.apache.thrift.protocol.TType.DOUBLE, (short)9);
   private static final org.apache.thrift.protocol.TField KEY_CACHE_SIZE_FIELD_DESC = new org.apache.thrift.protocol.TField("key_cache_size", org.apache.thrift.protocol.TType.DOUBLE, (short)11);
   private static final org.apache.thrift.protocol.TField ROW_CACHE_SAVE_PERIOD_IN_SECONDS_FIELD_DESC = new org.apache.thrift.protocol.TField("row_cache_save_period_in_seconds", org.apache.thrift.protocol.TType.I32, (short)19);
@@ -133,6 +134,7 @@ public class CfDef implements org.apache.thrift.TBase<CfDef, CfDef._Fields>, jav
   public String cells_per_row_to_cache; // optional
   public int min_index_interval; // optional
   public int max_index_interval; // optional
+  public int hint_time_to_live_seconds; // optional
   /**
    * @deprecated
    */
@@ -216,6 +218,7 @@ public class CfDef implements org.apache.thrift.TBase<CfDef, CfDef._Fields>, jav
     CELLS_PER_ROW_TO_CACHE((short)44, "cells_per_row_to_cache"),
     MIN_INDEX_INTERVAL((short)45, "min_index_interval"),
     MAX_INDEX_INTERVAL((short)46, "max_index_interval"),
+    HINT_TIME_TO_LIVE_SECONDS((short)47, "hint_time_to_live_seconds"),
     /**
      * @deprecated
      */
@@ -338,6 +341,8 @@ public class CfDef implements org.apache.thrift.TBase<CfDef, CfDef._Fields>, jav
           return MIN_INDEX_INTERVAL;
         case 46: // MAX_INDEX_INTERVAL
           return MAX_INDEX_INTERVAL;
+        case 47: // HINT_TIME_TO_LIVE_SECONDS
+          return HINT_TIME_TO_LIVE_SECONDS;
         case 9: // ROW_CACHE_SIZE
           return ROW_CACHE_SIZE;
         case 11: // KEY_CACHE_SIZE
@@ -415,20 +420,21 @@ public class CfDef implements org.apache.thrift.TBase<CfDef, CfDef._Fields>, jav
   private static final int __DEFAULT_TIME_TO_LIVE_ISSET_ID = 8;
   private static final int __MIN_INDEX_INTERVAL_ISSET_ID = 9;
   private static final int __MAX_INDEX_INTERVAL_ISSET_ID = 10;
-  private static final int __ROW_CACHE_SIZE_ISSET_ID = 11;
-  private static final int __KEY_CACHE_SIZE_ISSET_ID = 12;
-  private static final int __ROW_CACHE_SAVE_PERIOD_IN_SECONDS_ISSET_ID = 13;
-  private static final int __KEY_CACHE_SAVE_PERIOD_IN_SECONDS_ISSET_ID = 14;
-  private static final int __MEMTABLE_FLUSH_AFTER_MINS_ISSET_ID = 15;
-  private static final int __MEMTABLE_THROUGHPUT_IN_MB_ISSET_ID = 16;
-  private static final int __MEMTABLE_OPERATIONS_IN_MILLIONS_ISSET_ID = 17;
-  private static final int __REPLICATE_ON_WRITE_ISSET_ID = 18;
-  private static final int __MERGE_SHARDS_CHANCE_ISSET_ID = 19;
-  private static final int __ROW_CACHE_KEYS_TO_SAVE_ISSET_ID = 20;
-  private static final int __POPULATE_IO_CACHE_ON_FLUSH_ISSET_ID = 21;
-  private static final int __INDEX_INTERVAL_ISSET_ID = 22;
+  private static final int __HINT_TIME_TO_LIVE_SECONDS_ISSET_ID = 11;
+  private static final int __ROW_CACHE_SIZE_ISSET_ID = 12;
+  private static final int __KEY_CACHE_SIZE_ISSET_ID = 13;
+  private static final int __ROW_CACHE_SAVE_PERIOD_IN_SECONDS_ISSET_ID = 14;
+  private static final int __KEY_CACHE_SAVE_PERIOD_IN_SECONDS_ISSET_ID = 15;
+  private static final int __MEMTABLE_FLUSH_AFTER_MINS_ISSET_ID = 16;
+  private static final int __MEMTABLE_THROUGHPUT_IN_MB_ISSET_ID = 17;
+  private static final int __MEMTABLE_OPERATIONS_IN_MILLIONS_ISSET_ID = 18;
+  private static final int __REPLICATE_ON_WRITE_ISSET_ID = 19;
+  private static final int __MERGE_SHARDS_CHANCE_ISSET_ID = 20;
+  private static final int __ROW_CACHE_KEYS_TO_SAVE_ISSET_ID = 21;
+  private static final int __POPULATE_IO_CACHE_ON_FLUSH_ISSET_ID = 22;
+  private static final int __INDEX_INTERVAL_ISSET_ID = 23;
   private int __isset_bitfield = 0;
-  private _Fields optionals[] = {_Fields.COLUMN_TYPE,_Fields.COMPARATOR_TYPE,_Fields.SUBCOMPARATOR_TYPE,_Fields.COMMENT,_Fields.READ_REPAIR_CHANCE,_Fields.COLUMN_METADATA,_Fields.GC_GRACE_SECONDS,_Fields.DEFAULT_VALIDATION_CLASS,_Fields.ID,_Fields.MIN_COMPACTION_THRESHOLD,_Fields.MAX_COMPACTION_THRESHOLD,_Fields.KEY_VALIDATION_CLASS,_Fields.KEY_ALIAS,_Fields.COMPACTION_STRATEGY,_Fields.COMPACTION_STRATEGY_OPTIONS,_Fields.COMPRESSION_OPTIONS,_Fields.BLOOM_FILTER_FP_CHANCE,_Fields.CACHING,_Fields.DCLOCAL_READ_REPAIR_CHANCE,_Fields.MEMTABLE_FLUSH_PERIOD_IN_MS,_Fields.DEFAULT_TIME_TO_LIVE,_Fields.SPECULATIVE_RETRY,_Fields.TRIGGERS,_Fields.CELLS_PER_ROW_TO_CACHE,_Fields.MIN_INDEX_INTERVAL,_Fields.MAX_INDEX_INTERVAL,_Fields.ROW_CACHE_SIZE,_Fields.KEY_CACHE_SIZE,_Fields.ROW_CACHE_SAVE_PERIOD_IN_SECONDS,_Fields.KEY_CACHE_SAVE_PERIOD_IN_SECONDS,_Fields.MEMTABLE_FLUSH_AFTER_MINS,_Fields.MEMTABLE_THROUGHPUT_IN_MB,_Fields.MEMTABLE_OPERATIONS_IN_MILLIONS,_Fields.REPLICATE_ON_WRITE,_Fields.MERGE_SHARDS_CHANCE,_Fields.ROW_CACHE_PROVIDER,_Fields.ROW_CACHE_KEYS_TO_SAVE,_Fields.POPULATE_IO_CACHE_ON_FLUSH,_Fields.INDEX_INTERVAL};
+  private _Fields optionals[] = {_Fields.COLUMN_TYPE,_Fields.COMPARATOR_TYPE,_Fields.SUBCOMPARATOR_TYPE,_Fields.COMMENT,_Fields.READ_REPAIR_CHANCE,_Fields.COLUMN_METADATA,_Fields.GC_GRACE_SECONDS,_Fields.DEFAULT_VALIDATION_CLASS,_Fields.ID,_Fields.MIN_COMPACTION_THRESHOLD,_Fields.MAX_COMPACTION_THRESHOLD,_Fields.KEY_VALIDATION_CLASS,_Fields.KEY_ALIAS,_Fields.COMPACTION_STRATEGY,_Fields.COMPACTION_STRATEGY_OPTIONS,_Fields.COMPRESSION_OPTIONS,_Fields.BLOOM_FILTER_FP_CHANCE,_Fields.CACHING,_Fields.DCLOCAL_READ_REPAIR_CHANCE,_Fields.MEMTABLE_FLUSH_PERIOD_IN_MS,_Fields.DEFAULT_TIME_TO_LIVE,_Fields.SPECULATIVE_RETRY,_Fields.TRIGGERS,_Fields.CELLS_PER_ROW_TO_CACHE,_Fields.MIN_INDEX_INTERVAL,_Fields.MAX_INDEX_INTERVAL,_Fields.HINT_TIME_TO_LIVE_SECONDS,_Fields.ROW_CACHE_SIZE,_Fields.KEY_CACHE_SIZE,_Fields.ROW_CACHE_SAVE_PERIOD_IN_SECONDS,_Fields.KEY_CACHE_SAVE_PERIOD_IN_SECONDS,_Fields.MEMTABLE_FLUSH_AFTER_MINS,_Fields.MEMTABLE_THROUGHPUT_IN_MB,_Fields.MEMTABLE_OPERATIONS_IN_MILLIONS,_Fields.REPLICATE_ON_WRITE,_Fields.MERGE_SHARDS_CHANCE,_Fields.ROW_CACHE_PROVIDER,_Fields.ROW_CACHE_KEYS_TO_SAVE,_Fields.POPULATE_IO_CACHE_ON_FLUSH,_Fields.INDEX_INTERVAL};
   public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
     Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
@@ -493,6 +499,8 @@ public class CfDef implements org.apache.thrift.TBase<CfDef, CfDef._Fields>, jav
     tmpMap.put(_Fields.MIN_INDEX_INTERVAL, new org.apache.thrift.meta_data.FieldMetaData("min_index_interval", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I32)));
     tmpMap.put(_Fields.MAX_INDEX_INTERVAL, new org.apache.thrift.meta_data.FieldMetaData("max_index_interval", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
+        new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I32)));
+    tmpMap.put(_Fields.HINT_TIME_TO_LIVE_SECONDS, new org.apache.thrift.meta_data.FieldMetaData("hint_time_to_live_seconds", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I32)));
     tmpMap.put(_Fields.ROW_CACHE_SIZE, new org.apache.thrift.meta_data.FieldMetaData("row_cache_size", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.DOUBLE)));
@@ -626,6 +634,7 @@ public class CfDef implements org.apache.thrift.TBase<CfDef, CfDef._Fields>, jav
     }
     this.min_index_interval = other.min_index_interval;
     this.max_index_interval = other.max_index_interval;
+    this.hint_time_to_live_seconds = other.hint_time_to_live_seconds;
     this.row_cache_size = other.row_cache_size;
     this.key_cache_size = other.key_cache_size;
     this.row_cache_save_period_in_seconds = other.row_cache_save_period_in_seconds;
@@ -693,6 +702,8 @@ public class CfDef implements org.apache.thrift.TBase<CfDef, CfDef._Fields>, jav
     this.min_index_interval = 0;
     setMax_index_intervalIsSet(false);
     this.max_index_interval = 0;
+    setHint_time_to_live_secondsIsSet(false);
+    this.hint_time_to_live_seconds = 0;
     setRow_cache_sizeIsSet(false);
     this.row_cache_size = 0.0;
     setKey_cache_sizeIsSet(false);
@@ -1443,6 +1454,29 @@ public class CfDef implements org.apache.thrift.TBase<CfDef, CfDef._Fields>, jav
     __isset_bitfield = EncodingUtils.setBit(__isset_bitfield, __MAX_INDEX_INTERVAL_ISSET_ID, value);
   }
 
+  public int getHint_time_to_live_seconds() {
+    return this.hint_time_to_live_seconds;
+  }
+
+  public CfDef setHint_time_to_live_seconds(int hint_time_to_live_seconds) {
+    this.hint_time_to_live_seconds = hint_time_to_live_seconds;
+    setHint_time_to_live_secondsIsSet(true);
+    return this;
+  }
+
+  public void unsetHint_time_to_live_seconds() {
+    __isset_bitfield = EncodingUtils.clearBit(__isset_bitfield, __HINT_TIME_TO_LIVE_SECONDS_ISSET_ID);
+  }
+
+  /** Returns true if field hint_time_to_live_seconds is set (has been assigned a value) and false otherwise */
+  public boolean isSetHint_time_to_live_seconds() {
+    return EncodingUtils.testBit(__isset_bitfield, __HINT_TIME_TO_LIVE_SECONDS_ISSET_ID);
+  }
+
+  public void setHint_time_to_live_secondsIsSet(boolean value) {
+    __isset_bitfield = EncodingUtils.setBit(__isset_bitfield, __HINT_TIME_TO_LIVE_SECONDS_ISSET_ID, value);
+  }
+
   /**
    * @deprecated
    */
@@ -2047,6 +2081,14 @@ public class CfDef implements org.apache.thrift.TBase<CfDef, CfDef._Fields>, jav
       }
       break;
 
+    case HINT_TIME_TO_LIVE_SECONDS:
+      if (value == null) {
+        unsetHint_time_to_live_seconds();
+      } else {
+        setHint_time_to_live_seconds((Integer)value);
+      }
+      break;
+
     case ROW_CACHE_SIZE:
       if (value == null) {
         unsetRow_cache_size();
@@ -2240,6 +2282,9 @@ public class CfDef implements org.apache.thrift.TBase<CfDef, CfDef._Fields>, jav
     case MAX_INDEX_INTERVAL:
       return Integer.valueOf(getMax_index_interval());
 
+    case HINT_TIME_TO_LIVE_SECONDS:
+      return Integer.valueOf(getHint_time_to_live_seconds());
+
     case ROW_CACHE_SIZE:
       return Double.valueOf(getRow_cache_size());
 
@@ -2346,6 +2391,8 @@ public class CfDef implements org.apache.thrift.TBase<CfDef, CfDef._Fields>, jav
       return isSetMin_index_interval();
     case MAX_INDEX_INTERVAL:
       return isSetMax_index_interval();
+    case HINT_TIME_TO_LIVE_SECONDS:
+      return isSetHint_time_to_live_seconds();
     case ROW_CACHE_SIZE:
       return isSetRow_cache_size();
     case KEY_CACHE_SIZE:
@@ -2641,6 +2688,15 @@ public class CfDef implements org.apache.thrift.TBase<CfDef, CfDef._Fields>, jav
         return false;
     }
 
+    boolean this_present_hint_time_to_live_seconds = true && this.isSetHint_time_to_live_seconds();
+    boolean that_present_hint_time_to_live_seconds = true && that.isSetHint_time_to_live_seconds();
+    if (this_present_hint_time_to_live_seconds || that_present_hint_time_to_live_seconds) {
+      if (!(this_present_hint_time_to_live_seconds && that_present_hint_time_to_live_seconds))
+        return false;
+      if (this.hint_time_to_live_seconds != that.hint_time_to_live_seconds)
+        return false;
+    }
+
     boolean this_present_row_cache_size = true && this.isSetRow_cache_size();
     boolean that_present_row_cache_size = true && that.isSetRow_cache_size();
     if (this_present_row_cache_size || that_present_row_cache_size) {
@@ -2904,6 +2960,11 @@ public class CfDef implements org.apache.thrift.TBase<CfDef, CfDef._Fields>, jav
     builder.append(present_max_index_interval);
     if (present_max_index_interval)
       builder.append(max_index_interval);
+
+    boolean present_hint_time_to_live_seconds = true && (isSetHint_time_to_live_seconds());
+    builder.append(present_hint_time_to_live_seconds);
+    if (present_hint_time_to_live_seconds)
+      builder.append(hint_time_to_live_seconds);
 
     boolean present_row_cache_size = true && (isSetRow_cache_size());
     builder.append(present_row_cache_size);
@@ -3257,6 +3318,16 @@ public class CfDef implements org.apache.thrift.TBase<CfDef, CfDef._Fields>, jav
     }
     if (isSetMax_index_interval()) {
       lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.max_index_interval, other.max_index_interval);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
+    lastComparison = Boolean.valueOf(isSetHint_time_to_live_seconds()).compareTo(other.isSetHint_time_to_live_seconds());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetHint_time_to_live_seconds()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.hint_time_to_live_seconds, other.hint_time_to_live_seconds);
       if (lastComparison != 0) {
         return lastComparison;
       }
@@ -3640,6 +3711,12 @@ public class CfDef implements org.apache.thrift.TBase<CfDef, CfDef._Fields>, jav
       if (!first) sb.append(", ");
       sb.append("max_index_interval:");
       sb.append(this.max_index_interval);
+      first = false;
+    }
+    if (isSetHint_time_to_live_seconds()) {
+      if (!first) sb.append(", ");
+      sb.append("hint_time_to_live_seconds:");
+      sb.append(this.hint_time_to_live_seconds);
       first = false;
     }
     if (isSetRow_cache_size()) {
@@ -4045,6 +4122,14 @@ public class CfDef implements org.apache.thrift.TBase<CfDef, CfDef._Fields>, jav
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
+          case 47: // HINT_TIME_TO_LIVE_SECONDS
+            if (schemeField.type == org.apache.thrift.protocol.TType.I32) {
+              struct.hint_time_to_live_seconds = iprot.readI32();
+              struct.setHint_time_to_live_secondsIsSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
           case 9: // ROW_CACHE_SIZE
             if (schemeField.type == org.apache.thrift.protocol.TType.DOUBLE) {
               struct.row_cache_size = iprot.readDouble();
@@ -4431,6 +4516,11 @@ public class CfDef implements org.apache.thrift.TBase<CfDef, CfDef._Fields>, jav
         oprot.writeI32(struct.max_index_interval);
         oprot.writeFieldEnd();
       }
+      if (struct.isSetHint_time_to_live_seconds()) {
+        oprot.writeFieldBegin(HINT_TIME_TO_LIVE_SECONDS_FIELD_DESC);
+        oprot.writeI32(struct.hint_time_to_live_seconds);
+        oprot.writeFieldEnd();
+      }
       oprot.writeFieldStop();
       oprot.writeStructEnd();
     }
@@ -4529,46 +4619,49 @@ public class CfDef implements org.apache.thrift.TBase<CfDef, CfDef._Fields>, jav
       if (struct.isSetMax_index_interval()) {
         optionals.set(25);
       }
-      if (struct.isSetRow_cache_size()) {
+      if (struct.isSetHint_time_to_live_seconds()) {
         optionals.set(26);
       }
-      if (struct.isSetKey_cache_size()) {
+      if (struct.isSetRow_cache_size()) {
         optionals.set(27);
       }
-      if (struct.isSetRow_cache_save_period_in_seconds()) {
+      if (struct.isSetKey_cache_size()) {
         optionals.set(28);
       }
-      if (struct.isSetKey_cache_save_period_in_seconds()) {
+      if (struct.isSetRow_cache_save_period_in_seconds()) {
         optionals.set(29);
       }
-      if (struct.isSetMemtable_flush_after_mins()) {
+      if (struct.isSetKey_cache_save_period_in_seconds()) {
         optionals.set(30);
       }
-      if (struct.isSetMemtable_throughput_in_mb()) {
+      if (struct.isSetMemtable_flush_after_mins()) {
         optionals.set(31);
       }
-      if (struct.isSetMemtable_operations_in_millions()) {
+      if (struct.isSetMemtable_throughput_in_mb()) {
         optionals.set(32);
       }
-      if (struct.isSetReplicate_on_write()) {
+      if (struct.isSetMemtable_operations_in_millions()) {
         optionals.set(33);
       }
-      if (struct.isSetMerge_shards_chance()) {
+      if (struct.isSetReplicate_on_write()) {
         optionals.set(34);
       }
-      if (struct.isSetRow_cache_provider()) {
+      if (struct.isSetMerge_shards_chance()) {
         optionals.set(35);
       }
-      if (struct.isSetRow_cache_keys_to_save()) {
+      if (struct.isSetRow_cache_provider()) {
         optionals.set(36);
       }
-      if (struct.isSetPopulate_io_cache_on_flush()) {
+      if (struct.isSetRow_cache_keys_to_save()) {
         optionals.set(37);
       }
-      if (struct.isSetIndex_interval()) {
+      if (struct.isSetPopulate_io_cache_on_flush()) {
         optionals.set(38);
       }
-      oprot.writeBitSet(optionals, 39);
+      if (struct.isSetIndex_interval()) {
+        optionals.set(39);
+      }
+      oprot.writeBitSet(optionals, 40);
       if (struct.isSetColumn_type()) {
         oprot.writeString(struct.column_type);
       }
@@ -4673,6 +4766,9 @@ public class CfDef implements org.apache.thrift.TBase<CfDef, CfDef._Fields>, jav
       if (struct.isSetMax_index_interval()) {
         oprot.writeI32(struct.max_index_interval);
       }
+      if (struct.isSetHint_time_to_live_seconds()) {
+        oprot.writeI32(struct.hint_time_to_live_seconds);
+      }
       if (struct.isSetRow_cache_size()) {
         oprot.writeDouble(struct.row_cache_size);
       }
@@ -4721,7 +4817,7 @@ public class CfDef implements org.apache.thrift.TBase<CfDef, CfDef._Fields>, jav
       struct.setKeyspaceIsSet(true);
       struct.name = iprot.readString();
       struct.setNameIsSet(true);
-      BitSet incoming = iprot.readBitSet(39);
+      BitSet incoming = iprot.readBitSet(40);
       if (incoming.get(0)) {
         struct.column_type = iprot.readString();
         struct.setColumn_typeIsSet(true);
@@ -4869,54 +4965,58 @@ public class CfDef implements org.apache.thrift.TBase<CfDef, CfDef._Fields>, jav
         struct.setMax_index_intervalIsSet(true);
       }
       if (incoming.get(26)) {
+        struct.hint_time_to_live_seconds = iprot.readI32();
+        struct.setHint_time_to_live_secondsIsSet(true);
+      }
+      if (incoming.get(27)) {
         struct.row_cache_size = iprot.readDouble();
         struct.setRow_cache_sizeIsSet(true);
       }
-      if (incoming.get(27)) {
+      if (incoming.get(28)) {
         struct.key_cache_size = iprot.readDouble();
         struct.setKey_cache_sizeIsSet(true);
       }
-      if (incoming.get(28)) {
+      if (incoming.get(29)) {
         struct.row_cache_save_period_in_seconds = iprot.readI32();
         struct.setRow_cache_save_period_in_secondsIsSet(true);
       }
-      if (incoming.get(29)) {
+      if (incoming.get(30)) {
         struct.key_cache_save_period_in_seconds = iprot.readI32();
         struct.setKey_cache_save_period_in_secondsIsSet(true);
       }
-      if (incoming.get(30)) {
+      if (incoming.get(31)) {
         struct.memtable_flush_after_mins = iprot.readI32();
         struct.setMemtable_flush_after_minsIsSet(true);
       }
-      if (incoming.get(31)) {
+      if (incoming.get(32)) {
         struct.memtable_throughput_in_mb = iprot.readI32();
         struct.setMemtable_throughput_in_mbIsSet(true);
       }
-      if (incoming.get(32)) {
+      if (incoming.get(33)) {
         struct.memtable_operations_in_millions = iprot.readDouble();
         struct.setMemtable_operations_in_millionsIsSet(true);
       }
-      if (incoming.get(33)) {
+      if (incoming.get(34)) {
         struct.replicate_on_write = iprot.readBool();
         struct.setReplicate_on_writeIsSet(true);
       }
-      if (incoming.get(34)) {
+      if (incoming.get(35)) {
         struct.merge_shards_chance = iprot.readDouble();
         struct.setMerge_shards_chanceIsSet(true);
       }
-      if (incoming.get(35)) {
+      if (incoming.get(36)) {
         struct.row_cache_provider = iprot.readString();
         struct.setRow_cache_providerIsSet(true);
       }
-      if (incoming.get(36)) {
+      if (incoming.get(37)) {
         struct.row_cache_keys_to_save = iprot.readI32();
         struct.setRow_cache_keys_to_saveIsSet(true);
       }
-      if (incoming.get(37)) {
+      if (incoming.get(38)) {
         struct.populate_io_cache_on_flush = iprot.readBool();
         struct.setPopulate_io_cache_on_flushIsSet(true);
       }
-      if (incoming.get(38)) {
+      if (incoming.get(39)) {
         struct.index_interval = iprot.readI32();
         struct.setIndex_intervalIsSet(true);
       }

--- a/interface/thrift/gen-java/org/apache/cassandra/thrift/cassandraConstants.java
+++ b/interface/thrift/gen-java/org/apache/cassandra/thrift/cassandraConstants.java
@@ -56,6 +56,6 @@ import org.slf4j.LoggerFactory;
 
 public class cassandraConstants {
 
-  public static final String VERSION = "20.1.0";
+  public static final String VERSION = "20.2.0";
 
 }

--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -47,6 +47,7 @@ class Cql3ParsingRuleSet(CqlParsingRuleSet):
         ('gc_grace_seconds', None),
         ('min_index_interval', None),
         ('max_index_interval', None),
+        ('hint_time_to_live_seconds', None),
         ('read_repair_chance', None),
         ('default_time_to_live', None),
         ('speculative_retry', None),
@@ -466,7 +467,8 @@ def cf_prop_val_completer(ctxt, cass):
                     'dclocal_read_repair_chance'):
         return [Hint('<float_between_0_and_1>')]
     if this_opt in ('min_compaction_threshold', 'max_compaction_threshold',
-                    'gc_grace_seconds', 'min_index_interval', 'max_index_interval'):
+                    'gc_grace_seconds', 'min_index_interval', 'max_index_interval',
+                    'hint_time_to_live_seconds'):
         return [Hint('<integer>')]
     return [Hint('<option_value>')]
 

--- a/src/java/org/apache/cassandra/config/CFMetaData.java
+++ b/src/java/org/apache/cassandra/config/CFMetaData.java
@@ -75,6 +75,7 @@ public final class CFMetaData
     public final static SpeculativeRetry DEFAULT_SPECULATIVE_RETRY = new SpeculativeRetry(SpeculativeRetry.RetryType.PERCENTILE, 0.99);
     public final static int DEFAULT_MIN_INDEX_INTERVAL = 128;
     public final static int DEFAULT_MAX_INDEX_INTERVAL = 2048;
+    public final static int DEFAULT_HINT_TIME_TO_LIVE_SECONDS = -1;
 
     // Note that this is the default only for user created tables
     public final static String DEFAULT_COMPRESSOR = LZ4Compressor.class.getCanonicalName();
@@ -186,6 +187,7 @@ public final class CFMetaData
     private volatile CachingOptions caching = DEFAULT_CACHING_STRATEGY;
     private volatile int minIndexInterval = DEFAULT_MIN_INDEX_INTERVAL;
     private volatile int maxIndexInterval = DEFAULT_MAX_INDEX_INTERVAL;
+    private volatile int hintTimeToLiveSeconds = DEFAULT_HINT_TIME_TO_LIVE_SECONDS;
     private volatile int memtableFlushPeriod = 0;
     private volatile int defaultTimeToLive = DEFAULT_DEFAULT_TIME_TO_LIVE;
     private volatile SpeculativeRetry speculativeRetry = DEFAULT_SPECULATIVE_RETRY;
@@ -236,6 +238,7 @@ public final class CFMetaData
     public CFMetaData caching(CachingOptions prop) {caching = prop; return this;}
     public CFMetaData minIndexInterval(int prop) {minIndexInterval = prop; return this;}
     public CFMetaData maxIndexInterval(int prop) {maxIndexInterval = prop; return this;}
+    public CFMetaData hintTimeToLiveSeconds(int prop) {hintTimeToLiveSeconds = prop; return this;}
     public CFMetaData memtableFlushPeriod(int prop) {memtableFlushPeriod = prop; return this;}
     public CFMetaData defaultTimeToLive(int prop) {defaultTimeToLive = prop; return this;}
     public CFMetaData speculativeRetry(SpeculativeRetry prop) {speculativeRetry = prop; return this;}
@@ -409,6 +412,7 @@ public final class CFMetaData
                       .defaultTimeToLive(oldCFMD.defaultTimeToLive)
                       .minIndexInterval(oldCFMD.minIndexInterval)
                       .maxIndexInterval(oldCFMD.maxIndexInterval)
+                      .hintTimeToLiveSeconds(oldCFMD.hintTimeToLiveSeconds)
                       .speculativeRetry(oldCFMD.speculativeRetry)
                       .memtableFlushPeriod(oldCFMD.memtableFlushPeriod)
                       .droppedColumns(new HashMap<>(oldCFMD.droppedColumns))
@@ -621,6 +625,11 @@ public final class CFMetaData
         return maxIndexInterval;
     }
 
+    public int getHintTimeToLiveSeconds()
+    {
+        return hintTimeToLiveSeconds;
+    }
+
     public SpeculativeRetry getSpeculativeRetry()
     {
         return speculativeRetry;
@@ -680,6 +689,7 @@ public final class CFMetaData
             && Objects.equal(defaultTimeToLive, other.defaultTimeToLive)
             && Objects.equal(minIndexInterval, other.minIndexInterval)
             && Objects.equal(maxIndexInterval, other.maxIndexInterval)
+            && Objects.equal(hintTimeToLiveSeconds, other.hintTimeToLiveSeconds)
             && Objects.equal(speculativeRetry, other.speculativeRetry)
             && Objects.equal(droppedColumns, other.droppedColumns)
             && Objects.equal(triggers, other.triggers)
@@ -713,6 +723,7 @@ public final class CFMetaData
             .append(defaultTimeToLive)
             .append(minIndexInterval)
             .append(maxIndexInterval)
+            .append(hintTimeToLiveSeconds)
             .append(speculativeRetry)
             .append(droppedColumns)
             .append(triggers)
@@ -769,6 +780,7 @@ public final class CFMetaData
         caching = cfm.caching;
         minIndexInterval = cfm.minIndexInterval;
         maxIndexInterval = cfm.maxIndexInterval;
+        hintTimeToLiveSeconds = cfm.hintTimeToLiveSeconds;
         memtableFlushPeriod = cfm.memtableFlushPeriod;
         defaultTimeToLive = cfm.defaultTimeToLive;
         speculativeRetry = cfm.speculativeRetry;
@@ -1488,6 +1500,7 @@ public final class CFMetaData
             .append("defaultTimeToLive", defaultTimeToLive)
             .append("minIndexInterval", minIndexInterval)
             .append("maxIndexInterval", maxIndexInterval)
+            .append("hintTimeToLiveSeconds", hintTimeToLiveSeconds)
             .append("speculativeRetry", speculativeRetry)
             .append("droppedColumns", droppedColumns)
             .append("triggers", triggers.values())

--- a/src/java/org/apache/cassandra/cql3/statements/CFPropDefs.java
+++ b/src/java/org/apache/cassandra/cql3/statements/CFPropDefs.java
@@ -39,6 +39,7 @@ public class CFPropDefs extends PropertyDefinitions
     public static final String KW_DEFAULT_TIME_TO_LIVE = "default_time_to_live";
     public static final String KW_MIN_INDEX_INTERVAL = "min_index_interval";
     public static final String KW_MAX_INDEX_INTERVAL = "max_index_interval";
+    public static final String KW_HINT_TIME_TO_LIVE_SECONDS = "hint_time_to_live_seconds";
     public static final String KW_SPECULATIVE_RETRY = "speculative_retry";
     public static final String KW_BF_FP_CHANCE = "bloom_filter_fp_chance";
     public static final String KW_MEMTABLE_FLUSH_PERIOD = "memtable_flush_period_in_ms";
@@ -63,6 +64,7 @@ public class CFPropDefs extends PropertyDefinitions
         keywords.add(KW_DEFAULT_TIME_TO_LIVE);
         keywords.add(KW_MIN_INDEX_INTERVAL);
         keywords.add(KW_MAX_INDEX_INTERVAL);
+        keywords.add(KW_HINT_TIME_TO_LIVE_SECONDS);
         keywords.add(KW_SPECULATIVE_RETRY);
         keywords.add(KW_BF_FP_CHANCE);
         keywords.add(KW_COMPACTION);
@@ -204,6 +206,7 @@ public class CFPropDefs extends PropertyDefinitions
         cfm.memtableFlushPeriod(getInt(KW_MEMTABLE_FLUSH_PERIOD, cfm.getMemtableFlushPeriod()));
         cfm.minIndexInterval(getInt(KW_MIN_INDEX_INTERVAL, cfm.getMinIndexInterval()));
         cfm.maxIndexInterval(getInt(KW_MAX_INDEX_INTERVAL, cfm.getMaxIndexInterval()));
+        cfm.hintTimeToLiveSeconds(getInt(KW_HINT_TIME_TO_LIVE_SECONDS, cfm.getHintTimeToLiveSeconds()));
 
         if (compactionStrategyClass != null)
         {

--- a/src/java/org/apache/cassandra/schema/LegacySchemaTables.java
+++ b/src/java/org/apache/cassandra/schema/LegacySchemaTables.java
@@ -109,6 +109,7 @@ public class LegacySchemaTables
                 + "memtable_flush_period_in_ms int,"
                 + "min_compaction_threshold int,"
                 + "min_index_interval int,"
+                + "hint_time_to_live_seconds int,"
                 + "read_repair_chance double,"
                 + "speculative_retry text,"
                 + "subcomparator text,"
@@ -887,6 +888,7 @@ public class LegacySchemaTables
         adder.add("memtable_flush_period_in_ms", table.getMemtableFlushPeriod());
         adder.add("min_compaction_threshold", table.getMinCompactionThreshold());
         adder.add("min_index_interval", table.getMinIndexInterval());
+        adder.add("hint_time_to_live_seconds", table.getHintTimeToLiveSeconds());
         adder.add("read_repair_chance", table.getReadRepairChance());
         adder.add("speculative_retry", table.getSpeculativeRetry().toString());
 
@@ -1094,6 +1096,8 @@ public class LegacySchemaTables
         cfm.compactionStrategyClass(CFMetaData.createCompactionStrategy(result.getString("compaction_strategy_class")));
         cfm.compressionParameters(CompressionParameters.create(fromJsonMap(result.getString("compression_parameters"))));
         cfm.compactionStrategyOptions(fromJsonMap(result.getString("compaction_strategy_options")));
+        if (result.has("hint_time_to_live_seconds"))
+            cfm.hintTimeToLiveSeconds(result.getInt("hint_time_to_live_seconds"));
 
         if (result.has("min_index_interval"))
             cfm.minIndexInterval(result.getInt("min_index_interval"));

--- a/src/java/org/apache/cassandra/thrift/ThriftConversion.java
+++ b/src/java/org/apache/cassandra/thrift/ThriftConversion.java
@@ -274,6 +274,8 @@ public class ThriftConversion
                 newCFMD.minIndexInterval(cf_def.min_index_interval);
             if (cf_def.isSetMax_index_interval())
                 newCFMD.maxIndexInterval(cf_def.max_index_interval);
+            if (cf_def.isSetHint_time_to_live_seconds())
+                newCFMD.hintTimeToLiveSeconds(cf_def.hint_time_to_live_seconds);
             if (cf_def.isSetSpeculative_retry())
                 newCFMD.speculativeRetry(CFMetaData.SpeculativeRetry.fromString(cf_def.speculative_retry));
             if (cf_def.isSetTriggers())
@@ -324,6 +326,8 @@ public class ThriftConversion
             // ensure the max is at least as large as the min
             cf_def.setMax_index_interval(Math.max(cf_def.min_index_interval, CFMetaData.DEFAULT_MAX_INDEX_INTERVAL));
         }
+        if (!cf_def.isSetHint_time_to_live_seconds())
+            cf_def.setHint_time_to_live_seconds(CFMetaData.DEFAULT_HINT_TIME_TO_LIVE_SECONDS);
     }
 
     /**
@@ -385,6 +389,7 @@ public class ThriftConversion
         def.setBloom_filter_fp_chance(cfm.getBloomFilterFpChance());
         def.setMin_index_interval(cfm.getMinIndexInterval());
         def.setMax_index_interval(cfm.getMaxIndexInterval());
+        def.setHint_time_to_live_seconds(cfm.getHintTimeToLiveSeconds());
         def.setMemtable_flush_period_in_ms(cfm.getMemtableFlushPeriod());
         def.setCaching(cfm.getCaching().toThriftCaching());
         def.setCells_per_row_to_cache(cfm.getCaching().toThriftCellsPerRow());


### PR DESCRIPTION
It will be used to control hint expiry independently from
gc_grace_seconds. This option allows the operator to take advantage of hinted handoff without
having to set a large gc_grace_seconds.

Certain workloads can guarantee that replaying old hints will not resurrect
dead rows, even if more than gc_grace_seconds has expired since hint creation.

In particular, an insert-only, all-TTL workload with no overwrites would
benefit from gc_grace_seconds set to zero and still having hinted handoff
enabled.
