### PR TITLE
Set the default TTL for repair history tables to 30 days

### DIFF
--- a/src/java/org/apache/cassandra/repair/SystemDistributedKeyspace.java
+++ b/src/java/org/apache/cassandra/repair/SystemDistributedKeyspace.java
@@ -72,7 +72,8 @@ public final class SystemDistributedKeyspace
                      + "status text,"
                      + "started_at timestamp,"
                      + "finished_at timestamp,"
-                     + "PRIMARY KEY ((keyspace_name, columnfamily_name), id))");
+                     + "PRIMARY KEY ((keyspace_name, columnfamily_name), id)) "
+                     + "WITH default_time_to_live = 2592000");
 
     private static final CFMetaData ParentRepairHistory =
         compile(PARENT_REPAIR_HISTORY,
@@ -87,7 +88,8 @@ public final class SystemDistributedKeyspace
                      + "exception_stacktrace text,"
                      + "requested_ranges set<text>,"
                      + "successful_ranges set<text>,"
-                     + "PRIMARY KEY (parent_id))");
+                     + "PRIMARY KEY (parent_id)) "
+                     + "WITH default_time_to_live = 2592000");
 
     private static CFMetaData compile(String name, String description, String schema)
     {


### PR DESCRIPTION
Since there's no purging mechanism for those tables, rows will just keep on
accumulating in them and will eventually make the table too big to be useful.

A thirty day TTL seems reasonable to keep a lot of history for debugging, but
still prevent infinite buildup in the tables.
