### PR TITLE
Support SASI index scans on columns that are part of the partition key

### DIFF
--- a/src/java/org/apache/cassandra/index/sasi/disk/PerSSTableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sasi/disk/PerSSTableIndexWriter.java
@@ -117,7 +117,7 @@ public class PerSSTableIndexWriter implements SSTableFlushObserver
         Row row = (Row) unfiltered;
 
         supportedIndexes.keySet().forEach((column) -> {
-            ByteBuffer value = ColumnIndex.getValueOf(column, row, nowInSec);
+            ByteBuffer value = ColumnIndex.getValueOf(keyValidator, column, currentKey, row, nowInSec);
             if (value == null)
                 return;
 

--- a/src/java/org/apache/cassandra/index/sasi/plan/QueryPlan.java
+++ b/src/java/org/apache/cassandra/index/sasi/plan/QueryPlan.java
@@ -118,7 +118,7 @@ public class QueryPlan
                         while (partition.hasNext())
                         {
                             Unfiltered row = partition.next();
-                            if (operationTree.satisfiedBy(row, staticRow, true))
+                            if (operationTree.satisfiedBy(key, row, staticRow, true))
                                 clusters.add(row);
                         }
 

--- a/test/unit/org/apache/cassandra/SchemaLoader.java
+++ b/test/unit/org/apache/cassandra/SchemaLoader.java
@@ -645,6 +645,49 @@ public class SchemaLoader
         return cfm;
     }
 
+    public static CFMetaData partioningKeySASICFMD(String ksName, String cfName)
+    {
+        CFMetaData cfm = CFMetaData.Builder.create(ksName, cfName)
+                                           .addPartitionKey("sensor_id", Int32Type.instance)
+                                           .addRegularColumn("value", DoubleType.instance)
+                                           .build();
+
+        Indexes indexes = cfm.getIndexes();
+        indexes = indexes.with(IndexMetadata.fromSchemaMetadata("sensor_id", IndexMetadata.Kind.CUSTOM, new HashMap<String, String>()
+        {{
+            put(IndexTarget.CUSTOM_INDEX_OPTION_NAME, SASIIndex.class.getName());
+            put(IndexTarget.TARGET_OPTION_NAME, "sensor_id");
+            put("mode", OnDiskIndexBuilder.Mode.PREFIX.toString());
+            put("analyzer_class", "org.apache.cassandra.index.sasi.analyzer.NonTokenizingAnalyzer");
+            put("case_sensitive", "false");
+        }}));
+
+        cfm.indexes(indexes);
+        return cfm;
+    }
+
+    public static CFMetaData partioningCompositeKeySASICFMD(String ksName, String cfName)
+    {
+        CFMetaData cfm = CFMetaData.Builder.create(ksName, cfName)
+                                           .addPartitionKey("sensor_id", Int32Type.instance)
+                                           .addPartitionKey("date", TimestampType.instance)
+                                           .addRegularColumn("value", DoubleType.instance)
+                                           .build();
+
+        Indexes indexes = cfm.getIndexes();
+        indexes = indexes.with(IndexMetadata.fromSchemaMetadata("date", IndexMetadata.Kind.CUSTOM, new HashMap<String, String>()
+        {{
+            put(IndexTarget.CUSTOM_INDEX_OPTION_NAME, SASIIndex.class.getName());
+            put(IndexTarget.TARGET_OPTION_NAME, "date");
+            put("mode", OnDiskIndexBuilder.Mode.PREFIX.toString());
+            put("analyzer_class", "org.apache.cassandra.index.sasi.analyzer.NonTokenizingAnalyzer");
+            put("case_sensitive", "false");
+        }}));
+
+        cfm.indexes(indexes);
+        return cfm;
+    }
+
     public static CompressionParams getCompressionParameters()
     {
         return getCompressionParameters(null);


### PR DESCRIPTION
This is a partial port of the patch attached to CASSANDRA-11734 that avoids
some of the more expensive checks, while potentially limiting usage.

Only simple equality searches were tested, not range or LIKE queries.

Even with those caveats, the behaviour seems better than the unpatched code,
which simply does not create SASI files at all if the index has been created on
part of the partition key.

Until CASSANDRA-11734 lands in mainline Cassandra, this change will at least
allow using SASI for simple equality-based queries.