### PR TITLE
Wait for all management tasks to complete before shutting down CLSM

### DIFF
--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogSegmentManager.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogSegmentManager.java
@@ -105,14 +105,18 @@ public class CommitLogSegmentManager
         {
             public void runMayThrow() throws Exception
             {
-                while (run)
+                while (true)
                 {
                     try
                     {
                         Runnable task = segmentManagementTasks.poll();
                         if (task == null)
                         {
-                            // if we have no more work to do, check if we should create a new segment
+                            // if we have no more work to do, check if we were requested to exit before starting background tasks
+                            if (!run)
+                                return;
+
+                            // check if we should create a new segment
                             if (!atSegmentLimit() && availableSegments.isEmpty() && (activeSegments.isEmpty() || createReserveSegments))
                             {
                                 logger.trace("No segments in reserve; creating a fresh one");

--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogSegmentManagerTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogSegmentManagerTest.java
@@ -1,7 +1,9 @@
 package org.apache.cassandra.db.commitlog;
 
+import java.io.File;
 import java.nio.ByteBuffer;
 import java.util.Random;
+import java.util.UUID;
 import java.util.concurrent.Semaphore;
 
 import javax.naming.ConfigurationException;
@@ -96,5 +98,33 @@ public class CommitLogSegmentManagerTest
         clsm.getActiveSegments().forEach( segment -> clsm.recycleSegment(segment));
 
         Util.spinAssertEquals(3, () -> clsm.getActiveSegments().size(), 5);
+    }
+
+    @Test
+    @BMRule(name = "Make removing commitlog segments slow",
+            targetClass = "CommitLogSegment",
+            targetMethod = "discard",
+            action = "Thread.sleep(50)")
+    public void testShutdownWithPendingTasks() throws Throwable {
+        CommitLog.instance.resetUnsafe(true);
+        ColumnFamilyStore cfs1 = Keyspace.open(KEYSPACE1).getColumnFamilyStore(STANDARD1);
+
+        final Mutation m = new RowUpdateBuilder(cfs1.metadata, 0, "k")
+                           .clustering("bytes")
+                           .add("val", ByteBuffer.wrap(entropy))
+                           .build();
+
+        // force creating several commitlog files
+        for (int i = 0; i < 10; i++) {
+            CommitLog.instance.add(m);
+        }
+
+        // schedule discarding completed segments and immediately issue a shutdown
+        UUID cfid = m.getColumnFamilyIds().iterator().next();
+        CommitLog.instance.discardCompletedSegments(cfid, CommitLog.instance.getContext());
+        CommitLog.instance.shutdownBlocking();
+
+        // the shutdown should block until all logs except the currently active one and perhaps a new, empty one are gone
+        Assert.assertTrue(new File(CommitLog.instance.location).listFiles().length <= 2);
     }
 }


### PR DESCRIPTION
When draining, we shut down the CommitLog instance, which in turn shuts down
the CommitLogSegmentManager. Shutting it down without waiting for all its
management tasks to complete can lead to scheduling commitlogs for deletion,
but not actually deleting them, leading to a longer recovery after a restart.

Change the CLSM shutdown method to wait for all currently scheduled tasks to
complete before returning.

Reported upstream as CASSANDRA-13123